### PR TITLE
fix followship route

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@ app.set('view engine', 'hbs')
 app.use(express.urlencoded({ extended: true }))
 app.use(express.json())
 app.use(methodOverride('_method'))
+app.use(express.static('public'))
 
 app.use(session({ secret: SESSION_SECRET, resave: false, saveUninitialized: false }))
 app.use(passport.initialize())

--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -363,9 +363,12 @@ const userController = {
     .catch(err => next(err))
   },
   addFollowing: (req, res, next) => {
-    const UserId = Number(req.params.id)
+    const UserId = Number(req.body.id)
     const currentUserId = helpers.getUser(req).id
-    if (Number(UserId) === currentUserId) throw new Error('不能追蹤自己！')
+    if (UserId === currentUserId) {
+      // 測試檔規定需回傳狀態碼 200
+      return res.redirect(200, 'back')
+    }
     Promise.all([
       User.findByPk(UserId),
       Followship.findOne({

--- a/helpers/handlebars-helpers.js
+++ b/helpers/handlebars-helpers.js
@@ -8,7 +8,11 @@ dayjs.extend(localeData)
 dayjs.extend(relativeTime)
 
 module.exports = {
-  relativeTimeFromNow: a => dayjs(a).fromNow(),
+  relativeTimeFromNow: a => {
+    const time = dayjs(a).fromNow()
+    const timeWithoutSuffix = time.replace('前', '').trim()
+    return timeWithoutSuffix
+  },
   ifCond: function (a, b, options) {
     return a === b ? options.fn(this) : options.inverse(this)
   },

--- a/public/stylesheet/style.css
+++ b/public/stylesheet/style.css
@@ -1,0 +1,20 @@
+@media screen and (min-width: 1501px) {
+  #right-sidebar {
+    position: fixed;
+    left: 70%
+  }
+}
+
+@media screen and (min-width: 1194px) and (max-width: 1500px) {
+  #right-sidebar {
+    position: fixed;
+    right: 5%
+  }
+}
+
+
+@media screen and (max-width: 1193px) {
+  #right-sidebar {
+    display: none;
+  }
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -28,7 +28,7 @@ router.post('/signin', passport.authenticate('local', { failureRedirect: '/signi
 router.get('/logout', userController.logout)
 
 // 使用者功能路由
-router.post('/followships/:id', authenticated, userController.addFollowing)
+router.post('/followships', authenticated, userController.addFollowing)
 router.delete('/followships/:id', authenticated, userController.removeFollowing)
 router.get('/users/:id/likes', authenticated, userController.getUserLikes)
 router.get('/users/:id/replies', authenticated, userController.getUserReplies)

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -5,6 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My Twitter</title>
+  {{!-- public --}}
+  <link rel="stylesheet" href="/stylesheet/style.css" type="text/css" media="screen">
   {{!-- Bootstrap --}}
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">

--- a/views/partials/profile.hbs
+++ b/views/partials/profile.hbs
@@ -23,7 +23,8 @@
     <button type="submit" class="btn btn-primary" style="height:40px; width: 96px; border-radius: 50px; background-color: #FF6600; border:none;">正在跟隨</button>
   </form>
   {{else}}
-  <form action="/followships/{{user.id}}" method="POST">
+  <form action="/followships" method="POST">
+  <input type="text" name="id" value="{{user.id}}" class="d-none">
     <button type="submit" class="btn btn-default btn-block"
       style="margin-left: 10px; width:64px; height:40px; font-size: 15px; border-radius:50px; border-color: #FF6600; color:#FF6600;" >跟隨</button>
   </form>

--- a/views/partials/reply-modal.hbs
+++ b/views/partials/reply-modal.hbs
@@ -17,7 +17,7 @@
 
             <div class="d-flex align-items-start flex-column" style="min-height: 130px;">
               <div class="align-self-start">
-                <img class="rounded-circle" {{#if tweet}} src="{{tweet.User.avatar}}" {{else}}
+                <img class="rounded-circle ms-4" {{#if tweet}} src="{{tweet.User.avatar}}" {{else}}
                   src="{{this.User.avatar}}" {{/if}}title="source: imgur.com" style="width: 50px;height: 50px;"
                   class="ms-4">
                 <div class="d-inline-flex pt-3">

--- a/views/partials/right.hbs
+++ b/views/partials/right.hbs
@@ -1,45 +1,49 @@
+<div class="col-md-3 mt-4" style="width: 273px;" id="right-sidebar">
+  <div class="d-flex flex-column justify-content-start"
+    style="background-color: #FAFAFB; border-radius: 16px; width:273px">
 
-<div class="col-md-3 mt-4" style="width: 273px; position:fixed; left:997px; top: 16px">
-  <div class="d-flex flex-column justify-content-start" style="background-color: #FAFAFB; border-radius: 16px; width:273px">
-    
     <div class="px-4 py-3 border-bottom">
       <h4 style="color: #171725; font-weight: 500;">推薦跟隨</h4>
     </div>
-    
+
     {{#each topUser}}
-      <li class="list-group-item bg-light" style="border: none">
-        <div class="row justify-content-around align-items-center">
-      
-          <div class="col-3 d-flex justify-content-center align-items-center">
-            <a href="/users/{{this.id}}/tweets">
-              <img src="https://i.imgur.com/hpSLhnx.png" alt="user-avatar" width="50" height="50" class="rounded-circle">
-            </a>
-          </div>
-          <div class="col-4 pt-3 d-flex flex-column align-items-start" style="margin-left:-10px">
-            <h5 style="line-height: 18px; width:inherit;">{{this.name}}</h5>
-            <p class="text-muted" style="line-height: 16px; width:inherit;">@{{this.account}}</p>
-          </div>
-          {{!-- 追蹤鈕 --}}
-          <div class="col-5 d-flex justify-content-end">
-            {{#if this.isFollowed}}
-            <form action="/followships/{{this.id}}?_method=DELETE" method="POST" style="display: contents;">
-              <button type="submit" class="btn btn-primary"
-                style="height:40px; font-size: 15px; border-radius: 50px; background-color: #FF6600; border:none;">正在跟隨</button>
-            </form>
-            {{else}}
-            <form action="/followships/{{this.id}}" method="POST" style="display: contents;">
-              <button type="submit" class="btn btn-outline-light btn-block"
-                style="width:64px; height:40px; font-size: 15px; border-radius: 50px; border-color: #FF6600;">
-                <font color="#FF6600">跟隨</font>
-              </button>
-            </form>
-            {{/if}}
-          </div>
-      
+    {{#ifCond this.id ../currentUserId}}
+    {{else}}
+    <li class="list-group-item bg-light" style="border: none">
+      <div class="row justify-content-around align-items-center">
+
+        <div class="col-3 d-flex justify-content-center align-items-center">
+          <a href="/users/{{this.id}}/tweets">
+            <img src="https://i.imgur.com/hpSLhnx.png" alt="user-avatar" width="50" height="50" class="rounded-circle">
+          </a>
         </div>
-      </li>
-      {{/each}}
-      
+        <div class="col-4 pt-3 d-flex flex-column align-items-start" style="margin-left:-10px">
+          <h5 style="line-height: 18px; width:inherit;">{{this.name}}</h5>
+          <p class="text-muted" style="line-height: 16px; width:inherit;">@{{this.account}}</p>
+        </div>
+        {{!-- 追蹤鈕 --}}
+        <div class="col-5 d-flex justify-content-end">
+          {{#if this.isFollowed}}
+          <form action="/followships/{{this.id}}?_method=DELETE" method="POST" style="display: contents;">
+            <button type="submit" class="btn btn-primary"
+              style="height:40px; font-size: 15px; border-radius: 50px; background-color: #FF6600; border:none;">正在跟隨</button>
+          </form>
+          {{else}}
+          <form action="/followships" method="POST" style="display: contents;">
+            <input type="text" name="id" value="{{this.id}}" class="d-none">
+            <button type="submit" class="btn btn-outline-light btn-block"
+              style="width:64px; height:40px; font-size: 15px; border-radius: 50px; border-color: #FF6600;">
+              <font color="#FF6600">跟隨</font>
+            </button>
+          </form>
+          {{/if}}
+        </div>
+
+      </div>
+    </li>
+    {{/ifCond}}
+    {{/each}}
+
 
   </div>
 </div>

--- a/views/tweet.hbs
+++ b/views/tweet.hbs
@@ -16,7 +16,9 @@
         {{!-- 貼文 --}}
         <div class="d-flex flex-column border-bottom m-3">
           <div class="d-flex">
-            <img class="rounded-circle" src="{{tweet.User.avatar}}" title="source: imgur.com" style="width: 50px;height: 50px;" />
+            <a href="/users/{{tweet.User.id}}/tweets" style="text-decoration: none;">
+              <img class="rounded-circle" src="{{tweet.User.avatar}}" style="width: 50px;height: 50px;" />
+            </a>
             <div class="ms-2">
               <h5 style="color: #171725; font-size: 16px; margin-bottom: 0px">{{tweet.User.name}}</h5>
               <span style="color: #6C757D; font-size: 14px">@ {{tweet.User.account}}
@@ -59,10 +61,13 @@
         {{#each replies}}
         <div class="d-flex align-items-start flex-column border-top" style="min-height: 130px;">
           <div class="align-self-start pt-2">
-            <img src="{{this.User.avatar}}" title="source: imgur.com" style="width: 50px;height: 50px;" class="ms-4">
+            <a href="/users/{{this.User.id}}/tweets" style="text-decoration: none;">
+              <img src="{{this.User.avatar}}" style="width: 50px;height: 50px;" class="ms-4">
+            </a>
             <div class="d-inline-flex pt-3">
               <h5 class="mx-2" style="color: #171725; font-size: 16px; font-weight: 700">{{this.User.name}}</h5>
-              <span style="color: #6C757D; font-weight: 400; font-size: 14px">@{{this.User.account}} · {{relativeTimeFromNow this.createdAt}}</span>
+              <span style="color: #6C757D; font-weight: 400; font-size: 14px">@{{this.User.account}} ·
+                {{relativeTimeFromNow this.createdAt}}</span>
             </div>
           </div>
           <div style="max-width: 528px; margin-left: 85px;">

--- a/views/tweets.hbs
+++ b/views/tweets.hbs
@@ -1,7 +1,5 @@
 <main class="container">
-
   <div class="row">
-    {{!-- 側邊欄 --}}
     {{>sidebar route='tweets'}}
 
 
@@ -14,7 +12,7 @@
       </nav>
       <div class="border" style="height: 130px;" data-bs-toggle="modal" data-bs-target="#postTweet">
         <div class="d-flex pt-3 ps-3">
-          <img class="rounded-circle" src="{{user.avatar}}" title="source: imgur.com" style="width: 50px;height: 50px;" />
+          <img class="rounded-circle" src="{{user.avatar}}" style="width: 50px;height: 50px;" />
           <p class="m-3" style="color: #6C757D;">有什麼新鮮事？</p>
         </div>
         <div class="d-flex flex-row-reverse">
@@ -30,7 +28,9 @@
         style="min-height: 130px;">
         <a href="/tweets/{{this.id}}/replies" style="text-decoration: none;">
           <div class="align-self-start">
-            <img src="{{this.User.avatar}}" title="source: imgur.com" style="width: 50px;height: 50px;" class="ms-4 rounded-circle">
+            <a href="/users/{{this.User.id}}/tweets" style="text-decoration:none">
+              <img src="{{this.User.avatar}}" style="width: 50px;height: 50px;" class="ms-4 rounded-circle">
+            </a>
             <div class="d-inline-flex pt-3">
               <h5 class="mx-2" style="color: #171725;">{{this.User.name}}</h5>
               <span style="color: #6C757D;">@{{this.User.account}} · {{relativeTimeFromNow this.createdAt}}</span>


### PR DESCRIPTION
1. 新增 style.css 檔案，調整右側推薦追蹤欄不同螢幕大小時的 position
2. 在首頁推文、特定推文頁、個人頁有大頭貼的地方加上 a 標籤，點擊頭貼後可瀏覽個人頁
3. 將推文顯示時間的字串去掉“前“，以符合設計圖
4. followship 通過測試：調整追蹤路由為 - post /followships、若追蹤者與被追蹤者的 id 相等時，回傳 200 狀態碼
5. 不能出現追蹤自己的按鈕：在 right.hbs 的 {{#each topUser}} 下增加 ifCond 判斷此迴圈裡若有自己，不需顯示 